### PR TITLE
Fix Tail For Really Large Numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# version 1.2.3
+# Version 1.2.3
 
 - Fixes for nft load command
   -  Always get token URI when loading an ERC-721 contract as the function is supported
@@ -7,6 +7,11 @@
       of an ERC-721 token
 - Update the nft verify command to add verification to owners even if enumerable not 
     supported
+- Update nft tail to use backoff on exception
+- Update dynamodb data service to not send numbers in queries that are out of bounds.
+  Set the value to null if it cannot be stored.
+  - update_token_quantity
+  - update_token_owner
 
 
 # Version 1.2.2


### PR DESCRIPTION
* Update nft tail to use backoff on exception
* Update dynamodb dats service to not send numbers in queries that are out of bounds. Set the value to null if it cannot be stored.
  * update_token_quantity
  * update_token_owner
